### PR TITLE
Change JWT secret key to one specific to Rails app

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::API
   before_action :authorized
   def encode_token(payload)
-    JWT.encode(payload, 's3cr3t')
+    JWT.encode(payload, Rails.application.secrets.secret_key_base)
   end
 
   def auth_header
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::API
       token = auth_header.split(' ')[1]
       # header: { 'Authorization': 'Bearer <token>' }
       begin
-        JWT.decode(token, 's3cr3t', true, algorithm: 'HS256')
+        JWT.decode(token, Rails.application.secrets.secret_key_base, true, algorithm: 'HS256')
       rescue JWT::DecodeError
         nil
       end


### PR DESCRIPTION
#### What’s this PR do?
This branch changes the JWT secret key to Rails.application.secrets.secret_key_base. This makes it so that only our app has access to this key for encoding and decoding of JWT
#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:

--------
- [x] I checked that the tests are running successfully before submitting this PR
